### PR TITLE
Cleanup Existing OEPs

### DIFF
--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -35,7 +35,7 @@ def symbol()
 
 Returns a `string`, the short symbol of the token - e.g. <code>"MYT"</code>.
 
-This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+This symbol should be short (3-8 characters is recommended), with no whitespace characters or new-lines and should be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
 
 ====decimals====
 
@@ -46,6 +46,7 @@ def decimals()
 Returns the number of decimals used by the token - e.g. <code>8</code>, means to divide the token amount by <code>100,000,000</code> to get its user representation.
 
 ====totalSupply====
+
 <pre>
 def totalSupply()
 </pre>
@@ -73,6 +74,7 @@ The parameters <code>from</code> and <code>to</code> must be 20-byte address. If
 The parameter <code>amount</code> is the number of tokens to transfer, must be greater than or equal to 0.
 
 ====transferMulti====
+
 <pre>
 def TransferMulti(args)
 
@@ -83,23 +85,30 @@ state = {
 }
 </pre>
 
-The transferMulti function allows the transferring of tokens from multiple <code>from</code> addresses to multiple <code>to</code> addresses with multiple <code>amount</code>s of tokens. The parameter is an array of objects, the object is a <code>state</code> struct, which contains three items: the sender address <code>from</code> (which must be 20-byte address), the receiver address <code>to</code> (which must be 20-byte address) and the <code>amount</code> of tokens to transfer. If any of the transfers fail, all of the transfers must be failed, and the method must <code>throw</code> an exception.
+The transferMulti function allows the transferring of tokens from multiple <code>from</code> addresses to multiple <code>to</code> addresses with multiple <code>amount</code>s of tokens.
+The parameter is an array of objects, the object is a <code>state</code> struct, which contains three items: the sender address <code>from</code> (which must be 20-byte address), the receiver address <code>to</code> (which must be 20-byte address) and the <code>amount</code> of tokens to transfer.
+If any of the transfers fail, all of the transfers must be failed, and the method must <code>throw</code> an exception.
 
 ====approve====
+
 <pre>
 def approve(owner, spender, amount)
 </pre>
 
-The approve function allows the <code>spender</code> address to withdraw tokens from the <code>owner</code> address, of up to <code>amount</code> tokens. If this function is called again it overwrites the current allowance with the new value.
-The parameters <code>owner</code> and <code>spender</code> must be 20-byte addresses. If not, this method must <code>throw</code> an exception.
+The approve function allows the <code>spender</code> address to withdraw tokens from the <code>owner</code> address, of up to <code>amount</code> tokens.
+If this function is called again it overwrites the current allowance with the new value.
+The parameters <code>owner</code> and <code>spender</code> must be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
 
 ====transferFrom====
+
 <pre>
 def transferFrom(spender, from, to, amount)
 </pre>
 
 The transferFrom method is used for a withdraw workflow - allowing the <code>spender</code> address to withdraw <code>amount</code> tokens from the <code>from</code> address and send it to the <code>to</code> address.
-The parameters <code>spender</code>, <code>from</code> and <code>to</code> must all be 20-byte addresses. If not, this method must <code>throw</code> an exception.
+The parameters <code>spender</code>, <code>from</code> and <code>to</code> must all be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
 
 ====allowance====
 
@@ -118,12 +127,11 @@ TransferEvent = RegisterAction("transfer", "from", "to", "amount")
 </pre>
 
 The event must be triggered when tokens are transferred, including zero value transfers.
-
 A token contract which creates new tokens must trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
-
 A token contract which burns tokens must trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
 
 ====approval====
+
 <pre>
 ApprovalEvent = RegisterAction("approval", "owner", "spender", "amount")
 </pre>
@@ -131,6 +139,5 @@ ApprovalEvent = RegisterAction("approval", "owner", "spender", "amount")
 The event must be triggered on any successful calls to approve.
 
 ===Implementation===
-====Example implementations are available at====
 
 OEP-4 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample_compiler2.0.py | Python Template]]

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -25,7 +25,7 @@ A standard token interface unifies all of tokens, allows token on ONT to be conv
 def name()
 </pre>
 
-Returns a `string`, the name of the token - e.g. "MyToken".
+Returns a <code>string</code>, the name of the token - e.g. "MyToken".
 
 ====symbol====
 
@@ -33,7 +33,7 @@ Returns a `string`, the name of the token - e.g. "MyToken".
 def symbol()
 </pre>
 
-Returns a `string`, the short symbol of the token - e.g. <code>"MYT"</code>.
+Returns a <code>string</code>, the short symbol of the token - e.g. <code>"MYT"</code>.
 
 This symbol should be short (3-8 characters is recommended), with no whitespace characters or new-lines and should be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
 

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -9,7 +9,8 @@
 
 ==Abstract==
 
-The OEP-4 Proposal is a standard interface for tokens. This standard allows for the implementation of a standard API for tokens within smart contracts.
+The OEP-4 Proposal is a standard interface for tokens.
+This standard allows for the implementation of a standard API for tokens within smart contracts.
 
 ==Motivation==
 

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -22,113 +22,115 @@ A standard token interface unifies all of tokens, allows token on ONT to be conv
 ====name====
 
 <pre>
-public static string name()
+def name()
 </pre>
 
-Returns the name of the token - e.g. "MyToken".
+Returns a `string`, the name of the token - e.g. "MyToken".
 
 ====symbol====
 
 <pre>
-public static string symbol()
+def symbol()
 </pre>
 
-Returns a short string symbol of the token - e.g. <code>"MYT"</code>.
+Returns a `string`, the short symbol of the token - e.g. <code>"MYT"</code>.
 
 This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
 
 ====decimals====
 
 <pre>
-public static byte decimals()
+def decimals()
 </pre>
 
 Returns the number of decimals used by the token - e.g. <code>8</code>, means to divide the token amount by <code>100,000,000</code> to get its user representation.
 
 ====totalSupply====
 <pre>
-public static BigInteger totalSupply()
+def totalSupply()
 </pre>
-Returns the total number of token.
+
+Returns the total number of tokens.
 
 ====balanceOf====
 
 <pre>
-public static BigInteger balanceOf(byte[] address)
+def balanceOf(address)
 </pre>
 
 Returns the token balance of the <code>address</code>.
 
-The parameter <code>address</code> SHOULD be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+The parameter <code>address</code> must be a 20-byte address. If not, this method must <code>throw</code> an exception.
 
 ====transfer====
 
 <pre>
-public static bool transfer(byte[] from, byte[] to, BigInteger amount)
+def transfer(from, to, amount)
 </pre>
 
 Transfers an <code>amount</code> of tokens from the <code>from</code> account to the <code>to</code> account.
-The parameters <code>from</code> and <code>to</code> SHOULD be 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
-The parameter <code>amount</code> is transfer value of token.
+The parameters <code>from</code> and <code>to</code> must be 20-byte address. If not, this method must <code>throw</code> an exception.
+The parameter <code>amount</code> is the number of tokens to transfer, must be greater than or equal to 0.
 
 ====transferMulti====
 <pre>
-public static bool TransferMulti(object[] args)
+def TransferMulti(args)
 
-public struct State
-{
-     public byte[] From;
-     public byte[] To;
-     public BigInteger Amount;
+state = {
+  from: <FROM ADDRESS>,
+  to: <TO ADDRESS>,
+  amount: <AMOUNT>
 }
 </pre>
 
-The transferMulti allows transfer amount of token from multiple <code>from</code> to multiple <code>to</code> multiple times.The parameter is object array, the object is <code>State</code> struct, which contains three items.<code>From</code> is transfer sender, which SHOULD be 20-byte address.<code>To</code> is transfer receiver, which
-also SHOULD be 20-byte address. <code>Amount</code> is transfer value of token. If any of transfer fail, all of the transfers SHOULD be failed, and the method SHOULD <code>throw</code> an exception.
+The transferMulti function allows the transferring of tokens from multiple <code>from</code> addresses to multiple <code>to</code> addresses with multiple <code>amount</code>s of tokens. The parameter is an array of objects, the object is a <code>state</code> struct, which contains three items: the sender address <code>from</code> (which must be 20-byte address), the receiver address <code>to</code> (which must be 20-byte address) and the <code>amount</code> of tokens to transfer. If any of the transfers fail, all of the transfers must be failed, and the method must <code>throw</code> an exception.
 
 ====approve====
 <pre>
-public static bool approve(byte[] owner, byte[] spender, BigInteger amount)
+def approve(owner, spender, amount)
 </pre>
 
-The approve allows <code>spender</code> to withdraw from <code>owner</code> account multiple times, up to the value <code>amount</code>.If this function is called again it overwrites the current allowance with value.
-The parameters <code>owner</code>and <code>spender</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+The approve function allows the <code>spender</code> address to withdraw tokens from the <code>owner</code> address, of up to <code>amount</code> tokens. If this function is called again it overwrites the current allowance with the new value.
+The parameters <code>owner</code> and <code>spender</code> must be 20-byte addresses. If not, this method must <code>throw</code> an exception.
 
 ====transferFrom====
 <pre>
-public static bool transferFrom(byte[] spender, byte[] from, byte[] to, BigInteger amount)
+def transferFrom(spender, from, to, amount)
 </pre>
 
-The transferFrom method is used for a withdraw workflow, allowing <code>spender</code> to withdraw <code>amount</code> of token from <code>from</code> account  to <code>to</code> account.
-The parameters <code>spender</code> <code>from</code> and <code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+The transferFrom method is used for a withdraw workflow - allowing the <code>spender</code> address to withdraw <code>amount</code> tokens from the <code>from</code> address and send it to the <code>to</code> address.
+The parameters <code>spender</code>, <code>from</code> and <code>to</code> must all be 20-byte addresses. If not, this method must <code>throw</code> an exception.
 
 ====allowance====
 
 <pre>
-public static BigInteger allowance(byte[] owner, byte[] spender)
+def allowance(owner, spender)
 </pre>
-Returns the amount which <code>spender</code> is still allowed to withdraw from <code>owner</code>
+
+Returns the amount which the <code>spender</code> address is still allowed to withdraw from the <code>owner</code> address.
 
 ===Events===
 
 ====transfer====
 
 <pre>
-public static event transfer(byte[] from, byte[] to, BigInteger amount)
+TransferEvent = RegisterAction("transfer", "from", "to", "amount")
 </pre>
-MUST trigger when tokens are transferred, including zero value transfers.
 
-A token contract which creates new tokens MUST trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+The event must be triggered when tokens are transferred, including zero value transfers.
 
-A token contract which burns tokens MUST trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
+A token contract which creates new tokens must trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+
+A token contract which burns tokens must trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
 
 ====approval====
 <pre>
-public static event approval(byte[] owner, byte[] spender, BigInteger amount)
+ApprovalEvent = RegisterAction("approval", "owner", "spender", "amount")
 </pre>
-MUST trigger on any successful call to approve.
+
+The event must be triggered on any successful calls to approve.
 
 ===Implementation===
 ====Example implementations are available at====
 
-OEP-4 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample.py | Python Template]]
+OEP-4 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample_compiler2.0.py | Python Template]]

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -9,11 +9,11 @@
 
 ==Abstract==
 
-The OEP-4 Proposal is a standard interface for tokens, this standard allows for the implementation of a standard API for tokens within smart contracts.
+The OEP-4 Proposal is a standard interface for tokens. This standard allows for the implementation of a standard API for tokens within smart contracts.
 
 ==Motivation==
 
-A standard token interface unifies all of tokens, allows token on ONT to be convenient used by other applications.
+A standard token interface which allows tokens on the Ontology blockchain to be conveniently used by other applications.
 
 ==Specification==
 

--- a/OEPS/OEP-5.mediawiki
+++ b/OEPS/OEP-5.mediawiki
@@ -79,6 +79,7 @@ Transfers the NFT from the owner address of <code>tokenId</code> to the <code>to
 <code>tokenId</code> should be string or bytearray.
 If the owner address of <code>tokenId</code> can't be determined, this method must <code>throw</code> an exception.
 <code>to</code> must be 20-byte address. If not, this method must <code>throw</code> an exception.
+After a transfer, if an address had been approved by the <code>approve</code> method, it should be cleared automatically.
 
 ====transferMulti====
 

--- a/OEPS/OEP-5.mediawiki
+++ b/OEPS/OEP-5.mediawiki
@@ -9,7 +9,8 @@
 
 ==Abstract==
 
-The OEP-5 Proposal is a standard interface for NFTs. This standard allows for the implementation of a standard API for NFTs within smart contracts.
+The OEP-5 Proposal is a standard interface for NFTs.
+This standard allows for the implementation of a standard API for NFTs within smart contracts.
 
 ==Motivation==
 

--- a/OEPS/OEP-5.mediawiki
+++ b/OEPS/OEP-5.mediawiki
@@ -9,11 +9,11 @@
 
 ==Abstract==
 
-The OEP-5 Proposal is a standard interface for NFTs, this standard allows for the implementation of a standard API for tokens within smart contracts.
+The OEP-5 Proposal is a standard interface for NFTs. This standard allows for the implementation of a standard API for NFTs within smart contracts.
 
 ==Motivation==
 
-A standard token interface of NFTs, allows token on ONT to be convenient used by other applications.
+A standard NFT interface which allows NFTs on the Ontology blockchain to be conveniently used by other applications.
 
 ==Specification==
 

--- a/OEPS/OEP-5.mediawiki
+++ b/OEPS/OEP-5.mediawiki
@@ -119,6 +119,8 @@ Either the token owner or the approved account can assign the ownership of the N
 <code>to</code> must be 20-byte addresses.
 If not, this method must <code>throw</code> an exception.
 
+===Optional Methods===
+
 ====tokenMetadata====
 
 <pre>

--- a/OEPS/OEP-5.mediawiki
+++ b/OEPS/OEP-5.mediawiki
@@ -25,7 +25,7 @@ A standard token interface of NFTs, allows token on ONT to be convenient used by
 def name()
 </pre>
 
-Returns a `string`, the name of the NFTs - e.g. "My Non-Fungibles".
+Returns a <code>string</code>, the name of the NFTs - e.g. "My Non-Fungibles".
 
 ====symbol====
 
@@ -33,7 +33,7 @@ Returns a `string`, the name of the NFTs - e.g. "My Non-Fungibles".
 def symbol()
 </pre>
 
-Returns a `string`, the short symbol of the NFTs - e.g. <code>"MNFT"</code>.
+Returns a <code>string</code>, the short symbol of the NFTs - e.g. <code>"MNFT"</code>.
 
 This symbol should be short (3-8 characters is recommended), with no whitespace characters or new-lines and should be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
 
@@ -64,7 +64,7 @@ If not, this method must <code>throw</code> an exception.
 def ownerOf(tokenId)
 </pre>
 
-Returns the address currently marked as the owner of <code>tokenId</code>.
+Returns the address currently marked as the owner of the NFT with id of <code>tokenId</code>.
 <code>tokenId</code> should be string or a bytearray.
 If the owner address of <code>tokenId</code> can't be determined, this method must <code>throw</code> an exception.
 

--- a/OEPS/OEP-5.mediawiki
+++ b/OEPS/OEP-5.mediawiki
@@ -21,113 +21,142 @@ A standard token interface of NFTs, allows token on ONT to be convenient used by
 
 ====name====
 
-<source lang="csharp">
-public static string name()
-</source>
+<pre>
+def name()
+</pre>
 
-Returns the name of the NFTs - e.g. "My Non-Fungibles".
+Returns a `string`, the name of the NFTs - e.g. "My Non-Fungibles".
 
 ====symbol====
-<source lang="csharp">
-public static string symbol()
-</source>
 
-Returns a short string symbol of the token - e.g. <code>"MNFT"</code>.
+<pre>
+def symbol()
+</pre>
 
-This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+Returns a `string`, the short symbol of the NFTs - e.g. <code>"MNFT"</code>.
+
+This symbol should be short (3-8 characters is recommended), with no whitespace characters or new-lines and should be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
 
 ====totalSupply====
-<source lang="csharp">
-public static BigInteger totalSupply()
-</source>
+
+<pre>
+def totalSupply()
+</pre>
+
 Returns the total number of NFTs.
 
 ====balanceOf====
 
-<source lang="csharp">
-public static BigInteger balanceOf(byte[] address)
-</source>
+<pre>
+def balanceOf(address)
+</pre>
 
 Returns the number of NFTs assigned to <code>address</code>.
 
-The parameter <code>address</code> SHOULD be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+The parameter <code>address</code> must be a 20-byte address.
+If not, this method must <code>throw</code> an exception.
 
 ===Ownership Methods===
+
 ==== ownerOf====
-<source lang="csharp">
-public static byte[] ownerOf(byte[] tokenId)
-</source>
-Returns the address currently marked as the owner of <code>tokenId</code>.If the <code>tokenId</code> cann't query an owner address,<code>tokenId</code> SHOULD be string or bytearray.
-this method SHOULD <code>throw</code> an exception.
+
+<pre>
+def ownerOf(tokenId)
+</pre>
+
+Returns the address currently marked as the owner of <code>tokenId</code>.
+<code>tokenId</code> should be string or a bytearray.
+If the owner address of <code>tokenId</code> can't be determined, this method must <code>throw</code> an exception.
 
 ====transfer====
-<source lang="csharp">
-public static bool transfer(byte[] to, byte[] tokenId)
-</source>
 
-Transfers an NFTs of tokens from the <code>from</code> account to the <code>to</code> account.
-<code>tokenId</code> SHOULD be string or bytearray.
-<code>to</code> SHOULD be 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+<pre>
+def transfer(to, tokenId)
+</pre>
+
+Transfers the NFT from the owner address of <code>tokenId</code> to the <code>to</code> address.
+<code>tokenId</code> should be string or bytearray.
+If the owner address of <code>tokenId</code> can't be determined, this method must <code>throw</code> an exception.
+<code>to</code> must be 20-byte address. If not, this method must <code>throw</code> an exception.
 
 ====transferMulti====
-<source lang="csharp">
-public static bool TransferMulti(object[] args)
 
-public struct State
-{
-     public byte[] To;
-     public byte[] TokenId;
+<pre>
+def TransferMulti(args)
+
+state = {
+  to: <TO ADDRESS>,
+  tokenId: <TOKEN ID>
 }
-</source>
+</pre>
 
-The transferMulti allows transfer multiple NFTs from multiple <code>from</code> to multiple <code>to</code> multiple times.The parameter is object array, the object is <code>State</code> struct.<code>To</code> is transfer receiver, which
-also SHOULD be 20-byte address.<code>tokenId</code> SHOULD be string or bytearray. If any of transfer fail, all of the transfers SHOULD be failed, and the method SHOULD <code>throw</code> an exception.
+The transferMulti function allows the transferring of multiple NFTs to multiple <code>to</code> addresses.
+The parameter is an array of objects, the object is a <code>state</code> struct, which contains two items: the receiver address <code>to</code> (which must be 20-byte address) and the <code>tokenId</code> of the NFT.
+If any of the transfers fail, all of the transfers must be failed, and the method must <code>throw</code> an exception.
 
 
 ====approve====
-<source lang="csharp">
-public static bool approve(byte[] to, byte[] tokeId)
-</source>
 
-The approve allows to grant an NFTs to<code>to</code> account multiple times.If this function is called again it overwrites <code>to</code> or <code>tokenId</code>.<code>tokenId</code> SHOULD be string or bytearray.
-<code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+<pre>
+def approve(to, tokenId)
+</pre>
+
+
+The approve function allows the <code>to</code> address to transfer the <code>tokenId</code> NFT.
+If this function is called again it overwrites the <code>to</code> address that can transfer the NFT.
+<code>tokenId</code> should be string or bytearray.
+The <code>to</code> address must be 20-byte address.
+If not, this method must <code>throw</code> an exception.
 
 ====takeOwnership====
-<source lang="csharp">
-public static bool takeOwnership(byte[] to, byte[] tokenId)
-</source>
-Either the token owner or the approved account can assign the ownership of the Non-fungible with ID <code>tokenId</code> to <code>to</code> address. <code>to</code> SHOULD be 20-byte addresses.<code>tokenId</code> SHOULD be string or bytearray. If not, this method SHOULD <code>throw</code> an exception.
+
+<pre>
+def takeOwnership(to, tokenId)
+</pre>
+
+Either the token owner or the approved account can assign the ownership of the NFT with the id <code>tokenId</code> to the <code>to</code> address.
+<code>tokenId</code> should be string or bytearray.
+<code>to</code> must be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
 
 ====tokenMetadata====
-<source lang="csharp">
-public static byte[] tokenMetadata(byte[] tokenId)
-</source>
-Returns the url referencing an external resource that contains metadata about the NFT associated with tokenId.<code>tokenId</code> SHOULD be string or bytearray. this method is OPTIONAL, but if you don't implement this method, the browser can't get basic info about the token.
 
-The url info string MUST be an IPFS or HTTP(S) base path.<br/>
+<pre>
+def tokenMetadata(tokenId)
+</pre>
+
+This method is optional.
+
+Returns the url referencing an external resource that contains metadata about the NFT associated with the id <code>tokenId</code>.
+<code>tokenId</code> should be string or bytearray.
+
+The url info string must be an IPFS or HTTP(S) base path.<br/>
 Metadata JSON Schema:<br/>
-* name (required) - The name contain the UTF-8 encoded name of specific NFT, which SHOULD be short (3-8 characters is recommended)
+* name (required) - The name contain the UTF-8 encoded name of specific NFT, which should be short (3-8 characters is recommended)
 * image (optional) - If the image exist, it MUST contain a PNG, JPEG, or JPG image with at least 300 pixels of detail in each dimension. (1:1 image is recommended)
-* description (optional) - If the description exist, it MUST contain a UTF-8 encoded textual description of the asset. The description SHOULD be 1500 characters or less.
+* description (optional) - If the description exist, it MUST contain a UTF-8 encoded textual description of the asset. The description should be 1500 characters or less.
 * other metadata (optional) - other extension information.
 
 ===Events===
+
 ====transfer====
-<source lang="csharp">
-public static event transfer(byte[] from, byte[] to, byte[] tokenId)
-</source>
-MUST trigger when tokens are transferred, including zero value transfers.
 
-A token contract which creates new NFTs MUST trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code>.
+<pre>
+TransferEvent = RegisterAction("transfer", "from", "to", "tokenId")
+</pre>
 
-A token contract which burns tokens MUST trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
+The event must be triggered when NFTs are transferred, including zero value transfers.
+A token contract which creates new NFTs must trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code>.
+A token contract which burns tokens must trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
 
 ====approval====
-<source lang="csharp">
-public static event approval(byte[] from, byte[] to, byte[] tokenId)
-</source>
-MUST trigger on any successful call to approve.
+
+<pre>
+ApprovalEvent = RegisterAction("approval", "from", "to", "tokenId")
+</pre>
+
+The event must be triggered on any successful calls to approve.
 
 ===Implementation===
-====Example implementations are available at====
-OEP-5 Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP5Sample/OEP5Sample.py | Python Template]]
+
+OEP-5 Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP5Sample/OEP5Sample_compiler2.0.py | Python Template]]

--- a/OEPS/OEP-8.mediawiki
+++ b/OEPS/OEP-8.mediawiki
@@ -8,12 +8,15 @@
 </pre>
 
 ==Abstract==
-The OEP-8 Proposal is a standard interface for Crypto Item, this standard allows you to transfer any amount of tokens for difference Crypto Item from one address to other address.
-It combines the advantage of OEP-4 and OEP-5, it is very convenient to transfer different types of Crypto Item.
+
+The OEP-8 Proposal is a standard interface for Crypto Items.
+This standard allows you to transfer any amount of tokens for different Crypto Items from one address to another address.
+It combines the advantages of OEP-4 and OEP-5 to make transferring different types of Crypto Items convenient.
 
 ==Motivation==
-With the development of smart contract DApp, the requirement of transferring different amount of different tokens is more and more intense. If you want to transfer difference amount of different tokens from one address to other address or do batch transfer, it is very difficult now.
-The OEP-8 Proposal can perfectly solve this problem. It is easy to do it.
+With the development of smart contracts and dApps, the requirement of transferring different amounts of different tokens has become more intense.
+If you want to transfer different amounts of different tokens from one address to another address or to do batch transfers, it is very difficult.
+The OEP-8 Proposal aims to solve this problem.
 
 ==Specification==
 ===Method===
@@ -133,4 +136,3 @@ MUST trigger on any successful call to approve.
 ==Implementation==
 ====Example implementations are available at====
 OEP-8 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP8Sample/OEP8Sample.py | Python Template]]
-

--- a/OEPS/OEP-8.mediawiki
+++ b/OEPS/OEP-8.mediawiki
@@ -94,7 +94,7 @@ def approve(from, to, tokenId, amount)
 The approve method allows to grant the <code>amount</code> of Crypto Items with the id <code>tokenId</code> from the <code>from</code> address to the <code>to</code> address.
 If this function is called again it overwrites the <code>amount</code> allowed for the <code>to</code> address.
 The parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
-If not, this method must throw an exception.
+If not, this method must <code>throw</code> an exception.
 
 ====transferFrom====
 
@@ -127,9 +127,9 @@ state = {
 }
 </pre>
 
-The approveMulti method allows to grant multiple <code>amount</code> of Crypto Items with the id <code>TokenId</code>.
-The Parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
-If not, this method must throw an exception.
+The approveMulti method allows to grant multiple <code>amount</code> of Crypto Items with the id <code>tokenId</code>.
+The parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
 
 ====transferFromMulti====
 
@@ -147,7 +147,7 @@ state = {
 
 The transferFromMulti method is used for a withdraw workflow - allowing multiple calls to <code>transferFrom</code>.
 The parameters <code>spender</code>, <code>from</code> and <code>to</code> must be 20-byte addresses.
-If not, this method must throw an exception.
+If not, this method must <code>throw</code> an exception.
 
 ==Event==
 

--- a/OEPS/OEP-8.mediawiki
+++ b/OEPS/OEP-8.mediawiki
@@ -19,120 +19,156 @@ If you want to transfer different amounts of different tokens from one address t
 The OEP-8 Proposal aims to solve this problem.
 
 ==Specification==
-===Method===
+
+===Methods===
+
 ====name====
+
 <pre>
-public static string name(byte[] tokenId)
+def name(tokenId)
 </pre>
-Returns the name of the Crypto Item <code>tokenId</code> - e.g. "My Crypto Item".
+
+Returns the name of the Crypto Item with id <code>tokenId</code> - e.g. "My Crypto Item".
 
 ====symbol====
+
 <pre>
-public static string symbol(byte[] tokenId)
+def symbol(tokenId)
 </pre>
-Returns a short string symbol of Crypto Item <code>tokenId</code> - e.g. <code>"MCI"</code>.
-This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+
+Returns a short string symbol of the Crypto Item with id <code>tokenId</code> - e.g. <code>"MCI"</code>.
+This symbol should be short (3-8 characters is recommended), with no whitespace characters or new-lines and should be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
 
 ====totalSupply====
+
 <pre>
-public static BigInteger symbol(byte[] tokenId)
+def totalSupply(tokenId)
 </pre>
-Returns the total number of Crypto Item <code>tokenId</code>.
+
+Returns the total number of Crypto Items with an id <code>tokenId</code>.
 
 ====balanceOf====
+
 <pre>
-public static BigInteger balanceOf(byte[] address, byte[] tokenId)
+def balanceOf(address, tokenId)
 </pre>
-Returns the number of Crypto Item <code>tokenId</code> assigned to <code>address</code>.
-The parameter <code>address</code> SHOULD be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+
+Returns the number of Crypto Items with the id <code>tokenId</code> assigned to <code>address</code>.
+The parameter <code>address</code> must be a 20-byte address.
+If not, this method must <code>throw</code> an exception.
 
 ====transfer====
+
 <pre>
-public static bool transfer(byte[] from, byte[] to, byte[] tokenId, BigInteger value)
+def transfer(from, to, tokenId, amount)
 </pre>
-Transfers <code>value</code> of Crypto Item <code>tokenId</code> from <code>from</code> account to <code>to</code> account.
-The parameters <code>from</code> and <code>to</code> SHOULD be 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
-<code>tokenId</code> is the id of Crypto Item. <code>value</code> is the amount of Crypto Item.
+
+Transfers <code>amount</code> of Crypto Items with the id <code>tokenId</code> from the <code>from</code> address to the <code>to</code> address.
+The parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
 
 ====transferMulti====
+
 <pre>
-public static bool transferMulti(object[] args)
-public struct State
-{
-    public byte[] From;
-    public byte[] To;
-    public byte[] TokenId;
-    public BigInteger Value;
+def TransferMulti(args)
+
+state = {
+  from: <FROM ADDRESS>,
+  to: <TO ADDRESS>,
+  tokenId: <TOKEN ID>,
+  amount: <AMOUNT>
 }
 </pre>
-The transferMulti method allows to transfer multiple <code>value</code> of Crypto Item <code>tokenId</code> from <code>from</code> account to <code>to</code> account.
-The parameters <code>from</code> and <code>to</code> SHOULD be 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
-<code>tokenId</code> is the id of Crypto Item. <code>value</code> is the amount of Crypto Item.
+
+The transferMulti method allows to transfer multiple times with varying <code>amount</code>s, <code>tokenId</code>s, <code>from</code> addresses and <code>to</code> addresses.
+The parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
+If any of the transfers fail, all of the transfers must be failed, and the method must <code>throw</code> an exception.
 
 ====approve====
+
 <pre>
-public static bool approve(byte[] from, byte[] to, byte[] tokenId, BigInteger value)
+def approve(from, to, tokenId, amount)
 </pre>
-The approve method allows to grant the amount <code>value</code> of Crypto Item <code>tokenId</code> from <code>from</code> account to <code>to</code> account.
-If this function is called again it overwrites tokenId or value.
-The Parameters <code>from</code> and <code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD throw an exception.
+
+The approve method allows to grant the <code>amount</code> of Crypto Items with the id <code>tokenId</code> from the <code>from</code> address to the <code>to</code> address.
+If this function is called again it overwrites the <code>amount</code> allowed for the <code>to</code> address.
+The parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must throw an exception.
 
 ====transferFrom====
+
 <pre>
-public static bool transferFrom(byte[] spender, byte[] from, byte[] to, byte[] tokenId, BigInteger value)
+def transferFrom(spender, from, to, tokenId, amount)
 </pre>
-The transferFrom method is used for a withdraw workflow, allowing <code>spender</code> to withdraw <code>amount</code> of Crypto Item <code>tokenId</code>  from <code>from</code> account to <code>to</code> account.
-The parameters <code>spender</code> <code>from</code> and <code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+
+The transferFrom method is used for a withdraw workflow - allowing the <code>spender</code> address to withdraw <code>amount</code> of Crypto Items with the id <code>tokenId</code> from the <code>from</code> address and send it to the <code>to</code> address.
+The parameters <code>spender</code>, <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must <code>throw</code> an exception.
 
 ====allowance====
+
 <pre>
-public static BigInteger allowance(byte[] owner, byte[] spender, byte[] tokenId)
+def allowance(owner, spender, tokenId)
 </pre>
-Returns the amount of Crypto Item <code>tokenId</code> which <code>spender</code> is still allowed to withdraw from <code>owner</code>.
+
+Returns the amount of Crypto Items with the id <code>tokenId</code> which <code>spender</code> is still allowed to withdraw from <code>owner</code>.
 
 ====approveMulti====
 <pre>
-public static bool approveMulti(object[] args)
-public struct State
-{
-    public byte[] From;
-    public byte[] To;
-    public byte[] TokenId;
-    public BigInteger Value;
+
+def approveMulti(args)
+
+state = {
+  from: <FROM ADDRESS>,
+  to: <TO ADDRESS>,
+  tokenId: <TOKEN ID>,
+  amount: <AMOUNT>
 }
 </pre>
 
-The approveMulti method allows to grant multiple amount <code>Value</code> of Crypto Item <code>TokenId</code> from <code>From</code> account to <code>To</code> account.
-The Parameters <code>From</code> and <code>To</code> SHOULD be 20-byte addresses. If not, this method SHOULD throw an exception.
+The approveMulti method allows to grant multiple <code>amount</code> of Crypto Items with the id <code>TokenId</code>.
+The Parameters <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must throw an exception.
 
 ====transferFromMulti====
+
 <pre>
-public static bool transferFromMulti(object[] args)
-public struct State
-{
-    public byte[] Spender;
-    public byte[] From;
-    public byte[] To;
-    public byte[] TokenId;
-    public BigInteger Value;
+def transferFromMulti(args)
+
+state = {
+  spender: <SPENDER ADDRESS>,
+  from: <FROM ADDRESS>,
+  to: <TO ADDRESS>,
+  tokenId: <TOKEN ID>,
+  amount: <AMOUNT>
 }
 </pre>
-The transferFromMulti method is used for a withdraw workflow, allowing multiple <code>Spender</code> to withdraw <code>Value</code> of Crypto Item <code>TokenId</code>  from <code>From</code> account to <code>To</code> account.
-The Parameters <code>Spender</code> <code>From</code> and <code>To</code> SHOULD be 20-byte addresses. If not, this method SHOULD throw an exception.
+
+The transferFromMulti method is used for a withdraw workflow - allowing multiple calls to <code>transferFrom</code>.
+The parameters <code>spender</code>, <code>from</code> and <code>to</code> must be 20-byte addresses.
+If not, this method must throw an exception.
 
 ==Event==
+
 ====transfer====
+
 <pre>
-public static bool transfer(byte[] from, byte[] to, byte[] tokenId, BigInteger value)
+TransferEvent = RegisterAction("transfer", "from", "to", "tokenId", "amount")
 </pre>
-MUST trigger when tokens are transferred, including zero value transfers.
+
+The event must be triggered when tokens are transferred, including zero value transfers.
+A token contract which creates new tokens must trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+A token contract which burns tokens must trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
 
 ====approval====
+
 <pre>
-public static bool approval(byte[] from, byte[] to, byte[] tokenId, BigInteger value)
+ApprovalEvent = RegisterAction("approval", "from", "to", "tokenId", "amount")
 </pre>
-MUST trigger on any successful call to approve.
+
+The event must be triggered on any successful calls to approve.
 
 ==Implementation==
-====Example implementations are available at====
-OEP-8 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP8Sample/OEP8Sample.py | Python Template]]
+
+OEP-8 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP8Sample/OEP8Sample_compiler2.0.py | Python Template]]


### PR DESCRIPTION
This PR is meant to cleanup the OEP4, OEP5 and OEP8 proposals. 

- It changes all of the code from C# to Python, resolves #45. 
- It cleans up the english in each of the proposals, making them clearer and improving readability.
- Standardizes the spacing and formatting of each proposal.
- Updates the example contracts to be using the version 2 compiler.