### PR TITLE
Update OEP-4 Example

### DIFF
--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -142,4 +142,5 @@ The event must be triggered on any successful calls to approve.
 ===Implementation===
 
 TowerBuilders OEP-4 Example: [[https://github.com/TowerBuilders/OEP4-Example | Python Template]]
+
 ONT-Avocados OEP-4 Example: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample_compiler2.0.py | Python Template]]

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -141,4 +141,4 @@ The event must be triggered on any successful calls to approve.
 
 ===Implementation===
 
-OEP-4 Python Template: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample_compiler2.0.py | Python Template]]
+TowerBuilders OEP-4 Example: [[https://github.com/TowerBuilders/OEP4-Example | Python Template]]

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -142,3 +142,4 @@ The event must be triggered on any successful calls to approve.
 ===Implementation===
 
 TowerBuilders OEP-4 Example: [[https://github.com/TowerBuilders/OEP4-Example | Python Template]]
+ONT-Avocados OEP-4 Example: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample_compiler2.0.py | Python Template]]

--- a/OEPS/OEP-4.mediawiki
+++ b/OEPS/OEP-4.mediawiki
@@ -141,6 +141,6 @@ The event must be triggered on any successful calls to approve.
 
 ===Implementation===
 
-TowerBuilders OEP-4 Example: [[https://github.com/TowerBuilders/OEP4-Example | Python Template]]
+TowerBuilders OEP-4 Example: [[https://github.com/TowerBuilders/OEP4-Example/blob/master/contract.py | Python Template]]
 
 ONT-Avocados OEP-4 Example: [[https://github.com/ONT-Avocados/python-template/blob/master/OEP4Sample/OEP4Sample_compiler2.0.py | Python Template]]


### PR DESCRIPTION
The TowerBuilders OEP-4 example contains numerous fixes and the repo is setup as a template so that GitHub users can quickly create an OEP-4 project from it.

Can view it here: https://github.com/TowerBuilders/OEP4-Example